### PR TITLE
corregão do bug not fond

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+# Redirecionar tudo para a pasta public
+RewriteCond %{REQUEST_URI} !^/public/
+RewriteRule ^(.*)$ public/$1 [L]
+
+# Se o arquivo/diretório não existir na pasta public, use o index.php
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^public/(.*)$ public/index.php [L] 

--- a/api/controllers/auth_controller.php
+++ b/api/controllers/auth_controller.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config/database.php';
-require_once '../models/Usuario.php';
-require_once '../controllers/log_controller.php';
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../models/Usuario.php';
+require_once __DIR__ . '/../controllers/log_controller.php';
 
 class AuthController {
     private $db;

--- a/api/controllers/lembrete_controller.php
+++ b/api/controllers/lembrete_controller.php
@@ -1,8 +1,8 @@
 <?php
-require_once '../config/database.php';
-require_once '../models/Lembrete.php';
-require_once '../utils/Validator.php';
-require_once '../controllers/log_controller.php';
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../models/Lembrete.php';
+require_once __DIR__ . '/../utils/Validator.php';
+require_once __DIR__ . '/../controllers/log_controller.php';
 
 class LembreteController {
     private $db;

--- a/api/controllers/log_controller.php
+++ b/api/controllers/log_controller.php
@@ -1,6 +1,6 @@
 <?php
-require_once '../config/database.php';
-require_once '../utils/Logger.php';
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../utils/Logger.php';
 
 class LogController {
     private $db;

--- a/api/controllers/transacao_controller.php
+++ b/api/controllers/transacao_controller.php
@@ -1,9 +1,9 @@
 <?php
-require_once '../config/database.php';
-require_once '../models/Transacao.php';
-require_once '../models/Categoria.php';
-require_once '../utils/Validator.php';
-require_once '../controllers/log_controller.php';
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../models/Transacao.php';
+require_once __DIR__ . '/../models/Categoria.php';
+require_once __DIR__ . '/../utils/Validator.php';
+require_once __DIR__ . '/../controllers/log_controller.php';
 
 class TransacaoController {
     private $db;

--- a/api/routes/auth.php
+++ b/api/routes/auth.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../controllers/auth_controller.php';
+require_once __DIR__ . '/../controllers/auth_controller.php';
 
 header('Content-Type: application/json');
 

--- a/api/routes/lembretes.php
+++ b/api/routes/lembretes.php
@@ -1,6 +1,6 @@
 <?php
-require_once '../controllers/AuthController.php';
-require_once '../controllers/LembreteController.php';
+require_once __DIR__ . '/../controllers/AuthController.php';
+require_once __DIR__ . '/../controllers/LembreteController.php';
 
 header('Content-Type: application/json');
 

--- a/api/routes/transacoes.php
+++ b/api/routes/transacoes.php
@@ -1,6 +1,6 @@
 <?php
-require_once '../controllers/AuthController.php';
-require_once '../controllers/TransacaoController.php';
+require_once __DIR__ . '/../controllers/AuthController.php';
+require_once __DIR__ . '/../controllers/TransacaoController.php';
 
 header('Content-Type: application/json');
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -2,10 +2,11 @@ RewriteEngine On
 RewriteBase /
 
 # Permitir acesso direto a arquivos e diretórios existentes
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
 
-# Redirecionar todas as requisições para a API
+# Redirecionar requisições para a API
 RewriteRule ^api/(.*)$ ../api/$1 [L]
 
 # Redirecionar todas as outras requisições para o index.php

--- a/public/db.php
+++ b/public/db.php
@@ -1,0 +1,20 @@
+<?php
+$host = "localhost";
+$db_name = "finance_db";
+$username = "root";
+$password = "";
+$port = 3306;
+
+try {
+    $pdo = new PDO(
+        "mysql:host=$host;port=$port;dbname=$db_name",
+        $username,
+        $password
+    );
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->exec("set names utf8");
+} catch(PDOException $e) {
+    echo "Erro na conexão: " . $e->getMessage();
+    exit;
+}
+?> 

--- a/public/index.php
+++ b/public/index.php
@@ -3,10 +3,11 @@ require_once __DIR__ . '/../api/controllers/auth_controller.php';
 
 $auth = new AuthController();
 
+// Usando caminhos relativos à URL base
 if ($auth->isLoggedIn()) {
-    header("Location: dashboard/dashboard.php");
+    header("Location: /dashboard/dashboard.php");
 } else {
-    header("Location: login/login.php");
+    header("Location: /login/login.php");
 }
 exit;
 ?> 

--- a/public/lembretes/lembretes.php
+++ b/public/lembretes/lembretes.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../../api/controllers/auth_controller.php';
+require_once __DIR__ . '/../../api/controllers/auth_controller.php';
 
 $auth = new AuthController();
 

--- a/public/login/login.php
+++ b/public/login/login.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../../api/controllers/auth_controller.php';
+require_once __DIR__ . '/../../api/controllers/auth_controller.php';
 
 $auth = new AuthController();
 


### PR DESCRIPTION

# Correções implementadas

1. **Problema inicial**: Erro "Not Found" com o Apache, mesmo quando o arquivo existia.

2. **Solução aplicada**:

## 1. Correção de caminhos relativos
- Substituímos caminhos relativos como `'../config/database.php'` por caminhos absolutos usando `__DIR__` (ex: `__DIR__ . '/../config/database.php'`) nos seguintes arquivos:
  - `api/controllers/auth_controller.php`
  - `api/controllers/log_controller.php`
  - `api/controllers/transacao_controller.php`
  - `api/controllers/lembrete_controller.php`
  - `api/routes/auth.php`
  - `api/routes/transacoes.php`
  - `api/routes/lembretes.php`
  - `public/login/login.php`
  - `public/lembretes/lembretes.php`

## 2. Criação de arquivo de conexão com banco de dados
- Criamos o arquivo `public/db.php` para resolver as referências a este arquivo nas páginas do frontend

## 3. Configurações do Apache
- Modificamos o arquivo `.htaccess` na pasta `public/` para melhorar o tratamento de arquivos estáticos
- Criamos um arquivo `.htaccess` na raiz do projeto para redirecionar corretamente as requisições

## 4. Redirecionamentos no frontend
- Ajustamos os redirecionamentos no `public/index.php` para usar caminhos absolutos em vez de relativos

## Resultado
As mudanças resolveram o problema, garantindo que:
1. Os arquivos incluídos via require/include sejam encontrados independentemente de onde o código é executado
2. As regras de redirecionamento do Apache funcionem corretamente
3. Os caminhos de navegação entre páginas estejam consistentes

Estas alterações seguem as melhores práticas para projetos PHP, usando caminhos absolutos baseados em `__DIR__` para garantir que as inclusões funcionem independentemente do contexto de execução.
